### PR TITLE
ttools: Fix exception type in assertEqualData() of tabletest.py

### DIFF
--- a/ttools/src/testcases/uk/ac/starlink/ttools/tabletest.py
+++ b/ttools/src/testcases/uk/ac/starlink/ttools/tabletest.py
@@ -170,7 +170,7 @@ class TableTest(unittest.TestCase):
     def assertEqualData(self, t1, t2):
         try:
             self.assertEquals(len(t1), len(t2))
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
         for ir, rows in enumerate(map(None, t1, t2)):
             self.assertEquals(rows[0], rows[1], "row %d" % ir)


### PR DESCRIPTION
When running the unit tests of ttools, I get the following error:

```
Testcase: testScripts(uk.ac.starlink.ttools.JyStiltsTest):	Caused an ERROR
null
Traceback (most recent call last):
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 206, in <module>
    TableTest().runTest()
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 182, in runTest
    test(self)
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 128, in testMultiIO
    self.ioMultiRoundTrip([messier, messier.cmd_every(3)], fmt)
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 163, in ioMultiRoundTrip
    self.assertEqualTable(otable, itable)
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 168, in assertEqualTable
    self.assertEqualData(t1, t2)
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 172, in assertEqualData
    self.assertEquals(len(t1), len(t2))
  File "$TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 172, in assertEqualData
    self.assertEquals(len(t1), len(t2))
TypeError: object of type 'JyStarTable' has no len()

	at org.python.core.Py.TypeError(Py.java:235)
	at org.python.core.PyObject.__len__(PyObject.java:567)
	at org.python.core.PyObjectDerived.__len__(PyObjectDerived.java:821)
	at org.python.core.__builtin__.len(__builtin__.java:713)
	at org.python.core.BuiltinFunctions.__call__(__builtin__.java:60)
	at org.python.core.PyObject.__call__(PyObject.java:391)
	at org.python.pycode._pyx5.assertEqualData$12($TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py:175)
	at org.python.pycode._pyx5.call_function($TTOOLS/src/testcases/uk/ac/starlink/ttools/tabletest.py)
[...]
	at org.python.core.__builtin__.execfile_flags(__builtin__.java:522)
	at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:225)
	at uk.ac.starlink.ttools.JyStiltsTest.execute(JyStiltsTest.java:51)
	at uk.ac.starlink.ttools.JyStiltsTest.testScripts(JyStiltsTest.java:46)
 ```
The cause is that the missing `__len__` attribute in `JyStarTable` does not lead to an `AttributeError` when `len()` is called, but a `TypeError`; at least with the current Jython version (I used 2.5.3). Therefore, the patch extends the allowed errors by `TypeError`. Then, the test passes.