### PR TITLE
ttools: set a default locale for test of formatted date/time output

### DIFF
--- a/ttools/src/testcases/uk/ac/starlink/ttools/func/TimesTest.java
+++ b/ttools/src/testcases/uk/ac/starlink/ttools/func/TimesTest.java
@@ -1,5 +1,6 @@
 package uk.ac.starlink.ttools.func;
 
+import java.util.Locale;
 import java.util.Random;
 import uk.ac.starlink.pal.Pal;
 import uk.ac.starlink.pal.mjDate;
@@ -14,6 +15,7 @@ public class TimesTest extends TestCase {
 
     public TimesTest( String name ) {
         super( name );
+        Locale.setDefault(Locale.ROOT);
     }
 
     public void testFixed() {


### PR DESCRIPTION
When running under a non-english locale (f.e. `de_DE`), the `TimesTest` fails:
```
Testsuite: uk.ac.starlink.ttools.func.TimesTest
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0,074 sec

Testcase: testExamples(uk.ac.starlink.ttools.func.TimesTest):	FAILED
expected:<[Tue 10 Oc]t, 95> but was:<[Di 10 Ok]t, 95>
junit.framework.ComparisonFailure: expected:<[Tue 10 Oc]t, 95> but was:<[Di 10 Ok]t, 95>
	at uk.ac.starlink.ttools.func.TimesTest.testExamples(TimesTest.java:113)
```
I am not sure whether `Times.dateToMjd()` is expected to output localized dates/times. If yes, the test should fix the locale so that the comparison with a fixed string doesn't fail with a different locale. This is what the patch does.