### PR TITLE
ttools: set encoding for VotCopyTest

### DIFF
--- a/ttools/src/testcases/uk/ac/starlink/ttools/task/VotCopyTest.java
+++ b/ttools/src/testcases/uk/ac/starlink/ttools/task/VotCopyTest.java
@@ -60,6 +60,7 @@ public class VotCopyTest extends TableTestCase {
         File file = File.createTempFile( "votcopy", ".vot" );
         file.deleteOnExit();
         env.setValue( "out", file.toString() )
+           .setValue( "charset", "utf-8" )
            .setValue( "href", "false" );
         new VotCopy().createExecutable( env ).execute();
         return file.toURI().toURL();


### PR DESCRIPTION
If the encoding is not set, the default is taken, which is not necessarily UTF-8. If it is not UTF-8, then the encoding of the unicode test cases silently fails and `?` characters are written instead, causing the tests to fail. This is f.e. the case in the Debian package build environment, where the default charset is still ASCII.

To be independent from the test environment, this patch explicitely sets the encoding.

I am however quite curious why the encoding of the output is not generally fixed (in `uk.ac.starlink.ttools.task.VotCopy`) to UTF-8, or why this at least is not the default.