### PR TITLE
Use hexadecimal code point for non-breaking space in UsageWriter

### DIFF
--- a/ttools/src/main/uk/ac/starlink/ttools/build/UsageWriter.java
+++ b/ttools/src/main/uk/ac/starlink/ttools/build/UsageWriter.java
@@ -210,7 +210,7 @@ public class UsageWriter {
     private static String nbsps( int count ) {
         StringBuffer sbuf = new StringBuffer( count );
         for ( int i = 0; i < count; i++ ) {
-            sbuf.append( "\u00a0" );
+            sbuf.append( "&#xA0;" );
         }
         return sbuf.toString();
     }


### PR DESCRIPTION
In many cases, the XML output goes to stdout, which is not necessarily UTF-8. To avoid having the non-breakable spaces displayed as "?", the explicite codepoint is used instead the use of the encoded character itself.