### PR TITLE
Fix ttools to run with Jython-2.7

### DIFF
--- a/ttools/src/main/uk/ac/starlink/ttools/build/JyStilts.java
+++ b/ttools/src/main/uk/ac/starlink/ttools/build/JyStilts.java
@@ -109,6 +109,7 @@ public class JyStilts {
         Class[] clazzes = IMPORT_CLASSES;
         List importList = new ArrayList();
         importList.add( "import jarray.array" );
+        importList.add( "from org.python.core.util import StringUtil" );
         for ( int ic = 0; ic < clazzes.length; ic++ ) {
             Class clazz = clazzes[ ic ];
             String clazzName = clazz.getName();
@@ -388,7 +389,7 @@ public class JyStilts {
                                     + "):",
             "    def __init__(self, file):",
             "        buf = file.read(-1)",
-            "        self._buffer = jarray.array(buf, 'b')",
+            "        self._buffer = StringUtil.toBytes(buf)",
             "        if hasattr(file, 'name'):",
             "            self.setName(file.name)",
             "    def getRawInputStream(self):",


### PR DESCRIPTION
Hi Mark,

I got Debian bug report [#877397](https://bugs.debian.org/877397) from Gilles Filippini (the Debian maintainer of jython), that ttools does not build with Jython 2.7, which I just forward:

> Hi,
> 
> I've just uploaded jython 2.7.1 to unstable. I've previously checked that starjava-ttools doesn't FTBFS against this new jython release, but I must have mistaken somehow because it fails now with:
> ```
> run-tests:
>     [junit] Testsuite: uk.ac.starlink.ttools.FactoryTest
>     [junit] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.488 sec
>     [junit] 
>     [junit] Testsuite: uk.ac.starlink.ttools.JyStiltsTest
>     [junit] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.21 sec
>     [junit] 
>     [junit] Testcase: testScripts(uk.ac.starlink.ttools.JyStiltsTest):	Caused an ERROR
>     [junit] null
>     [junit] Traceback (most recent call last):
>     [junit]   File "/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 213, in <module>
>     [junit]     TableTest().runTest(testdir)
>     [junit]   File "/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 188, in runTest
>     [junit]     test(self)
>     [junit]   File "/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 133, in testMultiIO
>     [junit]     self.ioMultiRoundTrip([messier, messier.cmd_every(3)], fmt)
>     [junit]   File "/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py", line 166, in ioMultiRoundTrip
>     [junit]     tables2 = stilts.treads(ifile)
>     [junit]   File "/<<PKGBUILDDIR>>/build/etc/stilts.py", line 1581, in treads
>     [junit]     datsrc = _JyDataSource(location)
>     [junit]   File "/<<PKGBUILDDIR>>/build/etc/stilts.py", line 1453, in __init__
>     [junit]     self._buffer = jarray.array(buf, 'b')
>     [junit] TypeError: Type not compatible with array type
>     [junit] 
>     [junit] 	at org.python.core.Py.TypeError(Py.java:265)
>     [junit] 	at org.python.core.PyArray.pyset(PyArray.java:1631)
>     [junit] 	at org.python.core.PyArray.set(PyArray.java:1616)
>     [junit] 	at org.python.core.PyArray.extendInternalIter(PyArray.java:828)
>     [junit] 	at org.python.core.PyArray.extendInternal(PyArray.java:809)
>     [junit] 	at org.python.core.PyArray.array(PyArray.java:208)
>     [junit] 	at org.python.core.PyArray.array(PyArray.java:187)
>     [junit] 	at org.python.modules.jarray.array(jarray.java:8)
>     [junit] 	at org.python.core.PyReflectedFunction.__call__(PyReflectedFunction.java:188)
>     [junit] 	at org.python.core.PyReflectedFunction.__call__(PyReflectedFunction.java:206)
>     [junit] 	at org.python.core.PyObject.__call__(PyObject.java:497)
>     [junit] 	at org.python.core.PyObject.__call__(PyObject.java:501)
>     [junit] 	at stilts$py.__init__$97(/<<PKGBUILDDIR>>/build/etc/stilts.py:1455)
>     [junit] 	at stilts$py.call_function(/<<PKGBUILDDIR>>/build/etc/stilts.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:308)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:199)
>     [junit] 	at org.python.core.PyFunction.__call__(PyFunction.java:482)
>     [junit] 	at org.python.core.PyMethod.instancemethod___call__(PyMethod.java:237)
>     [junit] 	at org.python.core.PyMethod.__call__(PyMethod.java:228)
>     [junit] 	at org.python.core.PyMethod.__call__(PyMethod.java:223)
>     [junit] 	at org.python.core.Deriveds.dispatch__init__(Deriveds.java:19)
>     [junit] 	at org.python.core.PyObjectDerived.dispatch__init__(PyObjectDerived.java:1112)
>     [junit] 	at org.python.core.PyType.type___call__(PyType.java:1822)
>     [junit] 	at org.python.core.PyType.__call__(PyType.java:1805)
>     [junit] 	at org.python.core.PyObject.__call__(PyObject.java:480)
>     [junit] 	at org.python.core.PyObject.__call__(PyObject.java:484)
>     [junit] 	at stilts$py.treads$103(/<<PKGBUILDDIR>>/build/etc/stilts.py:1586)
>     [junit] 	at stilts$py.call_function(/<<PKGBUILDDIR>>/build/etc/stilts.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:308)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:132)
>     [junit] 	at org.python.core.PyFunction.__call__(PyFunction.java:413)
>     [junit] 	at org.python.pycode._pyx7.ioMultiRoundTrip$11(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py:167)
>     [junit] 	at org.python.pycode._pyx7.call_function(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:171)
>     [junit] 	at org.python.core.PyFunction.__call__(PyFunction.java:434)
>     [junit] 	at org.python.core.PyMethod.__call__(PyMethod.java:156)
>     [junit] 	at org.python.pycode._pyx7.testMultiIO$7(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py:132)
>     [junit] 	at org.python.pycode._pyx7.call_function(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:139)
>     [junit] 	at org.python.core.PyFunction.__call__(PyFunction.java:413)
>     [junit] 	at org.python.pycode._pyx7.runTest$14(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py:187)
>     [junit] 	at org.python.pycode._pyx7.call_function(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyBaseCode.call(PyBaseCode.java:154)
>     [junit] 	at org.python.core.PyFunction.__call__(PyFunction.java:423)
>     [junit] 	at org.python.core.PyMethod.__call__(PyMethod.java:141)
>     [junit] 	at org.python.pycode._pyx7.f$0(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py:215)
>     [junit] 	at org.python.pycode._pyx7.call_function(/<<PKGBUILDDIR>>/src/testcases/uk/ac/starlink/ttools/tabletest.py)
>     [junit] 	at org.python.core.PyTableCode.call(PyTableCode.java:171)
>     [junit] 	at org.python.core.PyCode.call(PyCode.java:18)
>     [junit] 	at org.python.core.Py.runCode(Py.java:1614)
>     [junit] 	at org.python.core.__builtin__.execfile_flags(__builtin__.java:535)
>     [junit] 	at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:286)
>     [junit] 	at uk.ac.starlink.ttools.JyStiltsTest.execute(JyStiltsTest.java:51)
>     [junit] 	at uk.ac.starlink.ttools.JyStiltsTest.testScripts(JyStiltsTest.java:46)
>     [junit] 
>     [junit] 
> 
> BUILD FAILED
> /<<PKGBUILDDIR>>/build.xml:1502: Test uk.ac.starlink.ttools.JyStiltsTest failed
> ```
> Please find attached a patch proposal.
> 
> Thanks,
> 
> _g.