### PR TITLE
vo: Fix JSON example file

### DIFF
--- a/vo/src/testcases/uk/ac/starlink/vo/example.desise
+++ b/vo/src/testcases/uk/ac/starlink/vo/example.desise
@@ -10,7 +10,7 @@
     "ICRS": {
       "label": "ICRS",
       "description": "As defined by 1998AJ....116..516M.",
-      "wider": ["EQUATORIAL"],
+      "wider": ["EQUATORIAL"]
     },
     "B1875.0": {
       "label": "Bonner Durchmusterung System",
@@ -25,7 +25,7 @@
       "label": "ICRS 2",
       "description": "The reference system defined by 2027A&A..1234...12B",
       "preliminary": "",
-      "wider": ["EQUATORIAL"],
+      "wider": ["EQUATORIAL"]
      }
   }
 }


### PR DESCRIPTION
The JSON format is a bit picky when it comes to the use of `,`: they can be used only as a delimiter between items, but not after the last item. While the normal json reader is sloppy here, the android one (which we use in Debian due to license problems) is quite picky and throws a `JSONException` here.

So, we just remove the colons at the end.
