### PR TITLE
Make max column width configurable in HTML output

### DIFF
--- a/table/src/main/uk/ac/starlink/table/formats/HTMLTableWriter.java
+++ b/table/src/main/uk/ac/starlink/table/formats/HTMLTableWriter.java
@@ -1,19 +1,12 @@
 package uk.ac.starlink.table.formats;
 
+import uk.ac.starlink.table.*;
+
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import uk.ac.starlink.table.ColumnInfo;
-import uk.ac.starlink.table.MultiStarTableWriter;
-import uk.ac.starlink.table.RowSequence;
-import uk.ac.starlink.table.StarTable;
-import uk.ac.starlink.table.StarTableOutput;
-import uk.ac.starlink.table.StarTableWriter;
-import uk.ac.starlink.table.StreamStarTableWriter;
-import uk.ac.starlink.table.TableSequence;
-import uk.ac.starlink.table.Tables;
 
 /**
  * A StarTableWriter that outputs text to HTML.

--- a/table/src/main/uk/ac/starlink/table/formats/HTMLTableWriter.java
+++ b/table/src/main/uk/ac/starlink/table/formats/HTMLTableWriter.java
@@ -33,19 +33,24 @@ public class HTMLTableWriter extends StreamStarTableWriter
 
     private boolean standalone_;
     private boolean useRowGroups_;
+    private int maxWidth_;
 
     /**
      * Constructs a new writer with default characteristics.
      */
     public HTMLTableWriter() {
-        this( true, true  );
+        this( true, true, 200);
+    }
+
+    public HTMLTableWriter(int maxWidth) {
+        this( true, true, maxWidth);
     }
 
     /**
      * Constructs a new writer indicating whether it will produce complete
      * or partial HTML documents.
      */
-    public HTMLTableWriter( boolean standalone, boolean useRowGroups ) {
+    public HTMLTableWriter( boolean standalone, boolean useRowGroups, int maxWidth ) {
         setStandalone( standalone );
         useRowGroups_ = useRowGroups;
     }
@@ -189,7 +194,7 @@ public class HTMLTableWriter extends StreamStarTableWriter
                 String[] cells = new String[ ncol ];
                 for ( int icol = 0; icol < ncol; icol++ ) {
                     cells[ icol ] =
-                        colinfos[ icol ].formatValue( row[ icol ], 200 );
+                        colinfos[ icol ].formatValue( row[ icol ], this.maxWidth_ );
                 }
                 outputRow( ostrm, "TD", null, cells );
             }


### PR DESCRIPTION
I am using the `HTMLTableWriter` and the `AsciiTableWriter` to visualize tables with one very wide column.
I was able to workaround the max width in the `AsciiTableWriter` by overriding `getMaxWidth`, but I couldn't do the same for the `HTMLTableWriter` because it is hardcoded [here](https://github.com/Starlink/starjava/blob/775d48b611242f659bb143cf019ebc70ff6a6bb2/table/src/main/uk/ac/starlink/table/formats/HTMLTableWriter.java#L192), so I made this small change.

Note that I was not able to test if the software actually builds now, I just verified the syntax.