### PR TITLE
table: refine JTable overlong cell ellipsis positioning

### DIFF
--- a/table/src/main/uk/ac/starlink/table/gui/CustomLabelUI.java
+++ b/table/src/main/uk/ac/starlink/table/gui/CustomLabelUI.java
@@ -2,6 +2,7 @@ package uk.ac.starlink.table.gui;
 
 import java.awt.FontMetrics;
 import java.awt.Rectangle;
+import java.util.regex.Pattern;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -23,6 +24,8 @@ import javax.swing.plaf.basic.BasicLabelUI;
 public class CustomLabelUI extends BasicLabelUI {
     private static final String ELLIPSES = "...";
     private static final int ELLIPSES_LEN = ELLIPSES.length();
+    private static final Pattern EMBEDDED_WHITESPACE =
+        Pattern.compile( "[^\\s]\\s+[^\\s]" );
     private String displayedText_;
 
     /**
@@ -71,12 +74,12 @@ public class CustomLabelUI extends BasicLabelUI {
             return displayedText_;
         }
 
-
         /* Check if a truncation occurred, and if the text is long enough. If
          * the text is too short, there is no point in truncating differently.*/
         int displayedLength = displayedText_.length();
         if ( !displayedText_.equals( text ) &&
-             displayedLength > 2 * ELLIPSES_LEN ) {
+             displayedLength > 2 * ELLIPSES_LEN &&
+             isCentralElisionPreferred( text ) ) {
             int splitLength =
                 ( displayedLength + ELLIPSES_LEN ) / 2 - ELLIPSES_LEN;
             String beforeEllipses = displayedText_.substring( 0, splitLength );
@@ -93,5 +96,24 @@ public class CustomLabelUI extends BasicLabelUI {
         }
 
         return displayedText_;
+    }
+
+    /**
+     * Indicates whether text should be truncated by eliding text in the
+     * middle, rather than at the end.
+     *
+     * @param  txt  text to test
+     * @return   true if central elision is preferred
+     */
+    private boolean isCentralElisionPreferred( String txt ) {
+        if ( txt == null ||
+             txt.length() == 0 ||
+             txt.endsWith( ELLIPSES ) ||
+             EMBEDDED_WHITESPACE.matcher( txt ).find() ) {
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 }

--- a/topcat/src/docs/sun253.xml
+++ b/topcat/src/docs/sun253.xml
@@ -34926,8 +34926,8 @@ introduced since the last version:
         <ref id="form-histogram">histogram</ref> plots.</li>
     <li>Overlong text and array fields in the
         <ref id="TableViewerWindow">Data Window</ref>
-        are now displayed with an ellipsis (...) in the middle
-        rather than at the end.</li>
+        are now in some cases displayed with an ellipsis (...)
+        in the middle rather than at the end.</li>
     <li>Functions 
         <ref id="Coverage-uniqToOrder"><code>uniqToOrder</code></ref> and
         <ref id="Coverage-uniqToIndex"><code>uniqToIndex</code></ref>

--- a/ttools/src/docs/sun256.xml
+++ b/ttools/src/docs/sun256.xml
@@ -16035,8 +16035,8 @@ eds. C. Gabriel et al., ASP Conf. Ser. 351, p. 666 (2006)
         <ref id="layer-histogram">histogram</ref> plots.</li>
     <li>Overlong text and array fields in the
         <ref id="mode-gui"><code>gui</code></ref> output mode table
-        window are now displayed with an ellipsis (...) in the middle
-        rather than at the end.</li>
+        window are now in some cases displayed with an ellipsis (...)
+        in the middle rather than at the end.</li>
     <li>Functions
         <ref id="Coverage-uniqToOrder"><code>uniqToOrder</code></ref> and
         <ref id="Coverage-uniqToIndex"><code>uniqToIndex</code></ref>


### PR DESCRIPTION
Modify the recent change that elides overlong strings displayed in JTable cells in the middle; the ellipsis may now be placed either in the middle or at the end, depending on content.

Roughly, strings with embedded whitespace (which are likely to be natural language text or similar) are elided at the end, but long strings without embedded whitespace (which are more likely to be something hierarchical like a filename or URL) are elided in the middle.