### PR TITLE
topcat: add CellViewWindow

### DIFF
--- a/topcat/src/main/uk/ac/starlink/topcat/CellViewWindow.java
+++ b/topcat/src/main/uk/ac/starlink/topcat/CellViewWindow.java
@@ -1,0 +1,50 @@
+package uk.ac.starlink.topcat;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import javax.swing.JTextArea;
+
+/**
+ * Window for defining up a mutually exclusive group of subsets
+ * based on the values of a given table expression.
+ *
+ * @author   Fergus Baker
+ * @since    06 Mar 2026
+ */
+public class CellViewWindow extends AuxWindow {
+    String cellString_;
+    JTextArea textArea_;
+
+    /**
+     * Constructor.
+     *
+     * Initialises the Cell View window without any display text.
+     *
+     * @param title The title for this window.
+     * @param parent The parent component.
+     */
+    @SuppressWarnings("this-escape")
+    public CellViewWindow( String title, Component parent ) {
+        super(title, parent);
+        textArea_ = new JTextArea( 5, 25 );
+        textArea_.setEditable( false );
+        textArea_.setLineWrap( true );
+        textArea_.setWrapStyleWord( true );
+
+        /* These cause the this-escape warning, but are perfectly safe in this
+         * context. */
+        setPreferredSize( new Dimension( 300, 200 ) );
+        getContentPane().add( textArea_ );
+        addHelp( null );
+    }
+
+    /**
+     * Used to set the text to display in the Cell View window.
+     *
+     * @param text Text to display in this component.
+     */
+    public void setText( String text ) {
+        textArea_.selectAll();
+        textArea_.replaceSelection( text );
+    }
+}

--- a/topcat/src/main/uk/ac/starlink/topcat/TableViewerWindow.java
+++ b/topcat/src/main/uk/ac/starlink/topcat/TableViewerWindow.java
@@ -563,6 +563,30 @@ public class TableViewerWindow extends AuxWindow {
              popper.add( explodeAct );
         }
 
+        popper.addSeparator();
+
+        /* Get the current row that is being selected. */
+        final int jrow = rowSelectionModel_.getMinSelectionIndex();
+
+        /* Action to open the cell text in a viewer. */
+        Action viewCellAct =
+            new BasicAction( "View Cell", ResourceIcon.ZOOM_IN,
+                             "View the cell contents in a viewer." ) {
+                public void actionPerformed( ActionEvent evt ) {
+                    CellViewWindow cell_view =
+                        new CellViewWindow( "Cell Viewer", parent );
+                    TableModel tm = jtable_.getModel();
+                    String selectedCell = tm.getValueAt( jrow, jcol ).toString();
+                    cell_view.setText( selectedCell );
+                    cell_view.setVisible( true );
+                }
+            };
+
+        /* Only enable the Cell View option if something is selected. If no row
+         * column is selected, it will be displayed in deactived state. */
+        viewCellAct.setEnabled( jrow >= 0 && jcol >= 0 );
+        popper.add( viewCellAct );
+
         return popper;
     }
 


### PR DESCRIPTION
The "Cell View" is a new drop-down menu option when a user right-clicks on a cell in a TableViewerWindow. It pops open a small window that displays the full contents of that cell, with the idea being that it can be used to read the longer form textual descriptions that are stored in some tables.

Some screenshots:

Right clicking before selecting a cell shows a deactived menu item:

<img width="803" height="358" alt="cell-view-deactivated" src="https://github.com/user-attachments/assets/34f68111-7508-4f57-acfa-3375af6e8b14" />

After selecting a cell, it is active and directly under the mouse for ease of access (right click and then immediately left click):

<img width="803" height="358" alt="cell-view-activated" src="https://github.com/user-attachments/assets/b2a293e4-bbaf-4514-87db-7cd895c1b9a0" />

The cell view window itself:

<img width="438" height="298" alt="image" src="https://github.com/user-attachments/assets/acab8b7b-e263-44b9-8bd0-fb49ccfd9faf" />
